### PR TITLE
Feature / Settings Bug Fix

### DIFF
--- a/includes/class-ssp-settings.php
+++ b/includes/class-ssp-settings.php
@@ -1011,7 +1011,7 @@ class SSP_Settings {
 				$series_id  = 0;
 				if ( 'feed-details' === $section ) {
 
-					$feed_series = filter_input( INPUT_GET, 'feed-series', FILTER_SANITIZE_STRING );
+					$feed_series = filter_var( $_REQUEST['feed-series'], FILTER_SANITIZE_STRING );
 					if ( ! empty( $feed_series ) && 'default' !== $feed_series ) {
 
 						// Get selected series.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hlashbrooke, whyisjake, psykro, PodcastMotor
 Tags: podcast, audio, video, vodcast, rss, mp3, mp4, feed, itunes, podcasting, media, stitcher, google play, playlist
 Requires at least: 4.4
 Tested up to: 4.7.3
-Stable tag: 1.16.1
+Stable tag: 1.16.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 1.16.1
+ * Version: 1.16.2
  * Plugin URI: https://www.seriouslysimplepodcasting.com/
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: PodcastMotor


### PR DESCRIPTION
Recent issue reports suggested that there was a problem saving the Feed Details settings for feeds other than the default feed.

Upon regression to **1.15.2**, it was discovered that the save does work. Upon further investigation, the issue was narrowed down to the **register_settings** method in the **SSP_Settings** class.

Further digging reveled that the use if **filter_input** for **$feed_details** on _line 1014_ was the culprit. This was confirmed indefinitely by toggling between the use of filter_input and filter_var using $_REQUEST.

It is not obvious why, but a comment from this third part issue ( https://github.com/xwp/stream/issues/254 ) suggests this may be the cause:

"Because of a PHP confirmed bug, filter_input( INPUT_SERVER, 'anything' ) would return null on some implementations of FCGI/PHP 5.4 ( and probably older versions as well ).
https://bugs.php.net/bug.php?id=49184"