### PR TITLE
Feature / New iTunes Tags

### DIFF
--- a/includes/class-ssp-admin.php
+++ b/includes/class-ssp-admin.php
@@ -626,6 +626,16 @@ class SSP_Admin {
 									<input name="' . esc_attr( $k ) . '" type="hidden" id="' . esc_attr( $k ) . '" value="' . esc_attr( $data ) . '" />
 								</p>' . "\n";
 						break;
+
+                    case 'number':
+                        $html .= '<p>
+									<label class="ssp-episode-details-label" for="' . esc_attr( $k ) . '">' . wp_kses_post( $v['name'] ) . '</label>
+									<br/>
+									<input name="' . esc_attr( $k ) . '" type="number" min="0" id="' . esc_attr( $k ) . '" class="' . esc_attr( $class ) . '" value="' . esc_attr( $data ) . '" />
+									<br/>
+									<span class="description">' . wp_kses_post( $v['description'] ) . '</span>
+								</p>' . "\n";
+                        break;
 					
 					default:
 						$html .= '<p>
@@ -762,6 +772,59 @@ class SSP_Admin {
 			'section'          => 'info',
 			'meta_description' => __( 'The type of podcast episode - either Audio or Video', 'seriously-simple-podcasting' ),
 		);
+
+        /**
+         * New iTunes Tag Announced At WWDC 2017
+         */
+        $fields['itunes_episode_type'] = array(
+            'name'             => __( 'iTunes Episode Type:', 'seriously-simple-podcasting' ),
+            'description'      => '',
+            'type'             => 'radio',
+            'default'          => 'full',
+            'options'          => array(
+                'full' => __( 'Full: For Normal Episodes', 'seriously-simple-podcasting' ),
+                'trailer' => __( 'Trailer: Promote an Upcoming Show', 'seriously-simple-podcasting' ),
+                'bonus' => __( 'Bonus: For Extra Content Related To a Show', 'seriously-simple-podcasting' )
+            ),
+            'section'          => 'info',
+            'meta_description' => __( 'The iTunes Episode Type', 'seriously-simple-podcasting' ),
+        );
+
+        /**
+         * New iTunes Tag Announced At WWDC 2017
+         */
+        $fields['itunes_title'] = array(
+            'name'             => __( 'iTunes Episode Title (Exclude Your Series / Show Number):', 'seriously-simple-podcasting' ),
+            'description'      => __( 'The iTunes Episode Title. NO Series / Show Number Should Be Included.', 'seriously-simple-podcasting' ),
+            'type'             => 'text',
+            'default'          => get_the_title(),
+            'section'          => 'info',
+            'meta_description' => __( 'The iTunes Episode Title. NO Series / Show Number Should Be Included', 'seriously-simple-podcasting' ),
+        );
+
+        /**
+         * New iTunes Tag Announced At WWDC 2017
+         */
+        $fields['itunes_episode_number'] = array(
+            'name'             => __( 'iTunes Episode Number:', 'seriously-simple-podcasting' ),
+            'description'      => __( 'The iTunes Episode Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
+            'type'             => 'number',
+            'default'          => '',
+            'section'          => 'info',
+            'meta_description' => __( 'The iTunes Episode Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
+        );
+
+        /**
+         * New iTunes Tag Announced At WWDC 2017
+         */
+        $fields['itunes_season_number'] = array(
+            'name'             => __( 'iTunes Season Number:', 'seriously-simple-podcasting' ),
+            'description'      => __( 'The iTunes Season Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
+            'type'             => 'number',
+            'default'          => '',
+            'section'          => 'info',
+            'meta_description' => __( 'The iTunes Season Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
+        );
 		
 		// In v1.14+ the `audio_file` field can actually be either audio or video, but we're keeping the field name here for backwards compatibility
 		$fields['audio_file'] = array(

--- a/includes/class-ssp-admin.php
+++ b/includes/class-ssp-admin.php
@@ -596,6 +596,18 @@ class SSP_Admin {
 						$html .= '<span class="description">' . wp_kses_post( $v['description'] ) . '</span>
 								</p>' . "\n";
 						break;
+
+                    case 'select':
+                        $html .= '<p>
+									<span class="ssp-episode-details-label">' . wp_kses_post( $v['name'] ) . '</span><br/>';
+                        $html .= '<select name="' . esc_attr( $k ) . '" class="' . esc_attr( $class ) . '" id="' . esc_attr( $k ) . '_' . esc_attr( $option ) . '">';
+                        foreach ( $v['options'] as $option => $label ) {
+                            $html .= '<option ' . selected( $option, $data, false ) . ' value="' . esc_attr( $option ) . '">' . esc_attr( $label ) . '</option>';
+                        }
+                        $html .= '</select>';
+                        $html .= '<span class="description">' . wp_kses_post( $v['description'] ) . '</span>
+								</p>' . "\n";
+                        break;
 					
 					case 'datepicker':
 						$display_date = '';
@@ -776,23 +788,6 @@ class SSP_Admin {
         /**
          * New iTunes Tag Announced At WWDC 2017
          */
-        $fields['itunes_episode_type'] = array(
-            'name'             => __( 'iTunes Episode Type:', 'seriously-simple-podcasting' ),
-            'description'      => '',
-            'type'             => 'radio',
-            'default'          => '',
-            'options'          => array(
-                'full' => __( 'Full: For Normal Episodes', 'seriously-simple-podcasting' ),
-                'trailer' => __( 'Trailer: Promote an Upcoming Show', 'seriously-simple-podcasting' ),
-                'bonus' => __( 'Bonus: For Extra Content Related To a Show', 'seriously-simple-podcasting' )
-            ),
-            'section'          => 'info',
-            'meta_description' => __( 'The iTunes Episode Type', 'seriously-simple-podcasting' ),
-        );
-
-        /**
-         * New iTunes Tag Announced At WWDC 2017
-         */
         $fields['itunes_title'] = array(
             'name'             => __( 'iTunes Episode Title (Exclude Your Series / Show Number):', 'seriously-simple-podcasting' ),
             'description'      => __( 'The iTunes Episode Title. NO Series / Show Number Should Be Included.', 'seriously-simple-podcasting' ),
@@ -805,18 +800,6 @@ class SSP_Admin {
         /**
          * New iTunes Tag Announced At WWDC 2017
          */
-        $fields['itunes_episode_number'] = array(
-            'name'             => __( 'iTunes Episode Number:', 'seriously-simple-podcasting' ),
-            'description'      => __( 'The iTunes Episode Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
-            'type'             => 'number',
-            'default'          => '',
-            'section'          => 'info',
-            'meta_description' => __( 'The iTunes Episode Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
-        );
-
-        /**
-         * New iTunes Tag Announced At WWDC 2017
-         */
         $fields['itunes_season_number'] = array(
             'name'             => __( 'iTunes Season Number:', 'seriously-simple-podcasting' ),
             'description'      => __( 'The iTunes Season Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
@@ -824,6 +807,24 @@ class SSP_Admin {
             'default'          => '',
             'section'          => 'info',
             'meta_description' => __( 'The iTunes Season Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
+        );
+
+        /**
+         * New iTunes Tag Announced At WWDC 2017
+         */
+        $fields['itunes_episode_type'] = array(
+            'name'             => __( 'iTunes Episode Type:', 'seriously-simple-podcasting' ),
+            'description'      => '',
+            'type'             => 'select',
+            'default'          => '',
+            'options'          => array(
+                '' => __( 'Please Select', 'seriously-simple-podcasting' ),
+                'full' => __( 'Full: For Normal Episodes', 'seriously-simple-podcasting' ),
+                'trailer' => __( 'Trailer: Promote an Upcoming Show', 'seriously-simple-podcasting' ),
+                'bonus' => __( 'Bonus: For Extra Content Related To a Show', 'seriously-simple-podcasting' )
+            ),
+            'section'          => 'info',
+            'meta_description' => __( 'The iTunes Episode Type', 'seriously-simple-podcasting' ),
         );
 		
 		// In v1.14+ the `audio_file` field can actually be either audio or video, but we're keeping the field name here for backwards compatibility
@@ -863,6 +864,18 @@ class SSP_Admin {
 			'section'          => 'info',
 			'meta_description' => __( 'The size of the podcast episode for display purposes.', 'seriously-simple-podcasting' ),
 		);
+
+        /**
+         * New iTunes Tag Announced At WWDC 2017
+         */
+        $fields['itunes_episode_number'] = array(
+            'name'             => __( 'iTunes Episode Number:', 'seriously-simple-podcasting' ),
+            'description'      => __( 'The iTunes Episode Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
+            'type'             => 'number',
+            'default'          => '',
+            'section'          => 'info',
+            'meta_description' => __( 'The iTunes Episode Number. Leave Blank If None.', 'seriously-simple-podcasting' ),
+        );
 		
 		if ( ssp_is_connected_to_podcastmotor() ) {
 			$fields['filesize_raw'] = array(

--- a/includes/class-ssp-admin.php
+++ b/includes/class-ssp-admin.php
@@ -780,7 +780,7 @@ class SSP_Admin {
             'name'             => __( 'iTunes Episode Type:', 'seriously-simple-podcasting' ),
             'description'      => '',
             'type'             => 'radio',
-            'default'          => 'full',
+            'default'          => '',
             'options'          => array(
                 'full' => __( 'Full: For Normal Episodes', 'seriously-simple-podcasting' ),
                 'trailer' => __( 'Trailer: Promote an Upcoming Show', 'seriously-simple-podcasting' ),
@@ -797,7 +797,7 @@ class SSP_Admin {
             'name'             => __( 'iTunes Episode Title (Exclude Your Series / Show Number):', 'seriously-simple-podcasting' ),
             'description'      => __( 'The iTunes Episode Title. NO Series / Show Number Should Be Included.', 'seriously-simple-podcasting' ),
             'type'             => 'text',
-            'default'          => get_the_title(),
+            'default'          => '',
             'section'          => 'info',
             'meta_description' => __( 'The iTunes Episode Title. NO Series / Show Number Should Be Included', 'seriously-simple-podcasting' ),
         );

--- a/includes/class-ssp-settings.php
+++ b/includes/class-ssp-settings.php
@@ -753,10 +753,11 @@ class SSP_Settings {
                     'description' => __( 'The order in which you want your episodes to be consumed by iTunes', 'seriously-simple-podcasting' ),
                     'type'        => 'select',
                     'options'     => array(
+                            '' => __( 'Please Select', 'seriously-simple-podcasting' ),
                             'episodic' => __( 'Latest Episode First', 'seriously-simple-podcasting' ),
                             'serial' => __( 'Oldest to Newest', 'seriously-simple-podcasting' )
                     ),
-                    'default'     => 'episodic',
+                    'default'     => '',
                 ),
 				array(
 					'id'          => 'redirect_feed',

--- a/includes/class-ssp-settings.php
+++ b/includes/class-ssp-settings.php
@@ -744,6 +744,20 @@ class SSP_Settings {
 					'options'     => array( 'published' => __( 'Published date', 'seriously-simple-podcasting' ), 'recorded' => __( 'Recorded date', 'seriously-simple-podcasting' ) ),
 					'default'     => 'published',
 				),
+                /**
+                 * New iTunes Tag Announced At WWDC 2017
+                 */
+                array(
+                    'id'          => 'consume_order',
+                    'label'       => __( 'Series Consume Order', 'seriously-simple-podcasting' ),
+                    'description' => __( 'The order in which you want your episodes to be consumed by iTunes', 'seriously-simple-podcasting' ),
+                    'type'        => 'select',
+                    'options'     => array(
+                            'episodic' => __( 'Latest Episode First', 'seriously-simple-podcasting' ),
+                            'serial' => __( 'Oldest to Newest', 'seriously-simple-podcasting' )
+                    ),
+                    'default'     => 'episodic',
+                ),
 				array(
 					'id'          => 'redirect_feed',
 					'label'       => __( 'Redirect this feed to new URL', 'seriously-simple-podcasting' ),

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 1.17.3
+ * Version: 1.18.0
  * Plugin URI: https://www.seriouslysimplepodcasting.com/
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: PodcastMotor

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -254,7 +254,11 @@ echo '<?xml version="1.0" encoding="' . get_option('blog_charset') . '"?>' . "\n
 // Include RSS stylesheet
 if( $stylehseet_url ) {
 	echo '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylehseet_url ) . '"?>';
-} ?>
+}
+
+// Get iTunes Type
+$itunes_type = get_option( 'ss_podcasting_consume_order' . ( $series_id > 0 ? '_' . $series_id : null ) );
+?>
 
 <rss version="2.0"
 	xmlns:content="http://purl.org/rss/1.0/modules/content/"
@@ -276,8 +280,15 @@ if( $stylehseet_url ) {
 		<lastBuildDate><?php echo esc_html( mysql2date( 'D, d M Y H:i:s +0000', get_lastpostmodified( 'GMT' ), false ) ); ?></lastBuildDate>
 		<language><?php echo esc_html( $language ); ?></language>
 		<copyright><?php echo esc_html( $copyright ); ?></copyright>
-		<itunes:subtitle><?php echo esc_html( $subtitle ); ?></itunes:subtitle>
+        <itunes:subtitle><?php echo esc_html( $subtitle ); ?></itunes:subtitle>
 		<itunes:author><?php echo esc_html( $author ); ?></itunes:author>
+        <?php
+            if( $itunes_type ){
+                ?>
+        <itunes:type><?php echo $itunes_type; ?></itunes:type>
+                <?php
+            }
+        ?>
 		<googleplay:author><?php echo esc_html( $author ); ?></googleplay:author>
 		<googleplay:email><?php echo esc_html( $owner_email ); ?></googleplay:email>
 		<itunes:summary><?php echo esc_html( $podcast_description ); ?></itunes:summary>
@@ -445,7 +456,7 @@ if ( isset( $category1['category'] ) && $category1['category'] ) { ?>
 				$itunes_subtitle = str_replace( array( '>', '<', '\'', '"', '`', '[andhellip;]', '[&hellip;]', '[&#8230;]' ), array( '', '', '', '', '', '', '', '' ), $itunes_subtitle );
 				$itunes_subtitle = mb_substr( $itunes_subtitle, 0, 254 );
 				$itunes_subtitle = apply_filters( 'ssp_feed_item_itunes_subtitle', $itunes_subtitle, get_the_ID() );
-				
+
 				// Date recorded
 				$pubDateType = get_option( 'ss_podcasting_publish_date', 'published' );
 				if ($pubDateType === 'published' )
@@ -453,29 +464,47 @@ if ( isset( $category1['category'] ) && $category1['category'] ) { ?>
 				else	// 'recorded'
 					$pubDate = esc_html( mysql2date( 'D, d M Y H:i:s +0000', get_post_meta(  get_the_ID(), 'date_recorded', true ), false ) );
 
+				// New iTunes WWDC 2017 Tags
+                $itunes_episode_type = get_post_meta( get_the_ID(), 'itunes_episode_type', true );
+                $itunes_title = get_post_meta( get_the_ID(), 'itunes_title', true );
+                $itunes_episode_number = get_post_meta( get_the_ID(), 'itunes_episode_number', true );
+                $itunes_season_number = get_post_meta( get_the_ID(), 'itunes_season_number', true );
+
 		?>
 		<item>
-			<title><?php esc_html( the_title_rss() ); ?></title>
-			<link><?php esc_url( the_permalink_rss() ); ?></link>
-			<pubDate><?php echo $pubDate; ?></pubDate>
-			<dc:creator><?php echo $author; ?></dc:creator>
-			<guid isPermaLink="false"><?php esc_html( the_guid() ); ?></guid>
-			<description><![CDATA[<?php echo $description; ?>]]></description>
-			<itunes:subtitle><![CDATA[<?php echo $itunes_subtitle; ?>]]></itunes:subtitle>
-			<content:encoded><![CDATA[<?php echo $content; ?>]]></content:encoded>
-			<itunes:summary><![CDATA[<?php echo $itunes_summary; ?>]]></itunes:summary>
-			<googleplay:description><![CDATA[<?php echo $gp_description; ?>]]></googleplay:description>
-<?php if ( $episode_image ) { ?>
-			<itunes:image href="<?php echo esc_url( $episode_image ); ?>"></itunes:image>
-			<googleplay:image href="<?php echo esc_url( $episode_image ); ?>"></googleplay:image>
-<?php } ?>
-			<enclosure url="<?php echo esc_url( $enclosure ); ?>" length="<?php echo esc_attr( $size ); ?>" type="<?php echo esc_attr( $mime_type ); ?>"></enclosure>
-			<itunes:explicit><?php echo esc_html( $itunes_explicit_flag ); ?></itunes:explicit>
-			<googleplay:explicit><?php echo esc_html( $googleplay_explicit_flag ); ?></googleplay:explicit>
-			<itunes:block><?php echo esc_html( $block_flag ); ?></itunes:block>
-			<googleplay:block><?php echo esc_html( $block_flag ); ?></googleplay:block>
-			<itunes:duration><?php echo esc_html( $duration ); ?></itunes:duration>
-			<itunes:author><?php echo $author; ?></itunes:author>
+            <title><?php esc_html( the_title_rss() ); ?></title>
+            <link><?php esc_url( the_permalink_rss() ); ?></link>
+            <pubDate><?php echo $pubDate; ?></pubDate>
+            <dc:creator><?php echo $author; ?></dc:creator>
+            <guid isPermaLink="false"><?php esc_html( the_guid() ); ?></guid>
+            <description><![CDATA[<?php echo $description; ?>]]></description>
+            <itunes:subtitle><![CDATA[<?php echo $itunes_subtitle; ?>]]></itunes:subtitle>
+            <?php if( $itunes_episode_type ) : ?>
+            <itunes:episodeType><?php echo $itunes_episode_type; ?></itunes:episodeType>
+            <?php endif; ?>
+            <?php if( $itunes_title ): ?>
+            <itunes:title><![CDATA[<?php echo $itunes_title; ?>]]></itunes:title>
+            <?php endif; ?>
+            <?php if( $itunes_episode_number ): ?>
+            <itunes:episode><?php echo $itunes_episode_number; ?></itunes:episode>
+            <?php endif; ?>
+            <?php if( $itunes_season_number ): ?>
+            <itunes:season><?php echo $itunes_season_number; ?></itunes:season>
+            <?php endif; ?>
+            <content:encoded><![CDATA[<?php echo $content; ?>]]></content:encoded>
+            <itunes:summary><![CDATA[<?php echo $itunes_summary; ?>]]></itunes:summary>
+            <googleplay:description><![CDATA[<?php echo $gp_description; ?>]]></googleplay:description>
+            <?php if ( $episode_image ) { ?>
+            <itunes:image href="<?php echo esc_url( $episode_image ); ?>"></itunes:image>
+            <googleplay:image href="<?php echo esc_url( $episode_image ); ?>"></googleplay:image>
+            <?php } ?>
+            <enclosure url="<?php echo esc_url( $enclosure ); ?>" length="<?php echo esc_attr( $size ); ?>" type="<?php echo esc_attr( $mime_type ); ?>"></enclosure>
+            <itunes:explicit><?php echo esc_html( $itunes_explicit_flag ); ?></itunes:explicit>
+            <googleplay:explicit><?php echo esc_html( $googleplay_explicit_flag ); ?></googleplay:explicit>
+            <itunes:block><?php echo esc_html( $block_flag ); ?></itunes:block>
+            <googleplay:block><?php echo esc_html( $block_flag ); ?></googleplay:block>
+            <itunes:duration><?php echo esc_html( $duration ); ?></itunes:duration>
+            <itunes:author><?php echo $author; ?></itunes:author>
 		</item>
 <?php }
 } ?>


### PR DESCRIPTION
This PR takes into account the new and changed iTunes tags introduced at WWDC17. Series and episode specific controls have been added.