### PR TITLE
Subscribe Links Bug Fix

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -410,18 +410,38 @@ class SSP_Frontend {
 
 		$meta_display .= "<p>".__( 'Podcast:', 'seriously-simple-podcasting' )." ".$podcast_display."</p>";
 
+		$terms = get_the_terms( $episode_id, 'series' );
+
 		$itunes_url = get_option( 'ss_podcasting_itunes_url', '' );
+		$stitcher_url = get_option( 'ss_podcasting_stitcher_url', '' );
+		$google_play_url = get_option( 'ss_podcasting_google_play_url', '' );
+
+		if( is_array( $terms ) ){
+
+			if( isset( $terms[0] ) ){
+
+				if( FALSE !== get_option( 'ss_podcasting_itunes_url_'.$terms[0]->term_id, '' ) )
+					$itunes_url = get_option( 'ss_podcasting_itunes_url_'.$terms[0]->term_id, '' );
+
+				if( FALSE !== get_option( 'ss_podcasting_stitcher_url_'.$terms[0]->term_id, '' ) )
+					$stitcher_url = get_option( 'ss_podcasting_stitcher_url_'.$terms[0]->term_id, '' );
+
+				if( FALSE !== get_option( 'ss_podcasting_google_play_url_'.$terms[0]->term_id, '' ) )
+					$google_play_url = get_option( 'ss_podcasting_google_play_url_'.$terms[0]->term_id, '' );
+
+			}
+			
+		} 
+		
 		if ( ! empty( $itunes_url ) ) {
 			$subscribe_display .= '<a href="' . esc_url( $itunes_url ) . '" target="_blank" title="' . apply_filters( 'ssp_subscribe_link_name_itunes', __( 'iTunes', 'seriously-simple-podcasting' ) ) . '" class="podcast-meta-itunes">' . apply_filters( 'ssp_subscribe_link_name_itunes', __( 'iTunes', 'seriously-simple-podcasting' ) ) . '</a>';
 		}
-
-		$stitcher_url = get_option( 'ss_podcasting_stitcher_url', '' );
+		
 		if ( ! empty( $stitcher_url ) ) {
 			if( empty( $itunes_url ) ) { $meta_sep = ''; } else { $meta_sep = ' | '; }
 			$subscribe_display .= $meta_sep . '<a href="' . esc_url( $stitcher_url ) . '" target="_blank" title="' . apply_filters( 'ssp_subscribe_link_name_stitcher', __( 'Stitcher', 'seriously-simple-podcasting' ) ) . '" class="podcast-meta-itunes">' . apply_filters( 'ssp_subscribe_link_name_stitcher', __( 'Stitcher', 'seriously-simple-podcasting' ) ) . '</a>';
 		}
-
-		$google_play_url = get_option( 'ss_podcasting_google_play_url', '' );
+		
 		if ( ! empty( $google_play_url ) ) {
 			if( empty( $stitcher_url ) ) { $meta_sep = ''; } else { $meta_sep = ' | '; }
 			$subscribe_display .= $meta_sep . '<a href="' . esc_url( $google_play_url ) . '" target="_blank" title="' . apply_filters( 'ssp_subscribe_link_name_google_play', __( 'Google Play', 'seriously-simple-podcasting' ) ) . '" class="podcast-meta-itunes">' . apply_filters( 'ssp_subscribe_link_name_google_play', __( 'Google Play', 'seriously-simple-podcasting' ) ) . '</a>';


### PR DESCRIPTION
- Subscription links for series weren't being called at all and would default the the primary/main feed's URLs instead
- This commit will fix this, however we need to discuss what would be better in terms of how to handle the links if an episode is assigned to more than one episode