### PR TITLE
Added support for featured images

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -1254,6 +1254,10 @@ class SSP_Frontend {
 						$html .= $this->episode_meta_details( $episode_id, $episode_context );
 					break;
 
+					case 'image':
+						$html .= get_the_post_thumbnail( $episode_id, apply_filters( 'ssp_frontend_context_thumbnail_size', 'thumbnail' ) );
+						break;
+
 				}
 			}
 


### PR DESCRIPTION
- Useful for when a user wants to display a featured image in the podcast_episode or podcast_playlist shortcode.
- New filter added: ssp_frontend_context_thumbnail_size