### PR TITLE
Feature / HTML5 Media Player No Analytics

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -29,8 +29,8 @@
 }
 
 .ssp-player.ssp-player-large .ssp-album-art{
-    width: 150px;
-    height: 150px;
+    width: 155px;
+    height: 155px;
 }
 
 .ssp-player.ssp-player-large .ssp-player-inner{

--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -89,10 +89,10 @@ class SSP_Frontend {
 
 		// Trigger import podcast process (if active)
 		add_action( 'wp_loaded', array( $this, 'import_existing_podcast_to_podmotor') );
-		
+
 		// Update podmotor_episode_id and audio file values from import process
 		add_action( 'wp_loaded', array( $this, 'update_episode_data_from_podmotor') );
-		
+
 		// Register widgets
 		add_action( 'widgets_init', array( $this, 'register_widgets' ), 1 );
 
@@ -348,6 +348,10 @@ class SSP_Frontend {
                                 $series_image_attachment_id = ssp_get_image_id_from_url( $series_image );
                                 list( $src, $width, $height ) = wp_get_attachment_image_src( $series_image_attachment_id, 'medium' );
                                 $albumArt = compact( 'src', 'width', 'height' );
+                            }elseif( $series_image = get_option( "ss_podcasting_data_image" ) ){
+	                            $series_image_attachment_id = ssp_get_image_id_from_url( $series_image );
+	                            list( $src, $width, $height ) = wp_get_attachment_image_src( $series_image_attachment_id, 'medium' );
+	                            $albumArt = compact( 'src', 'width', 'height' );
                             }else{
                                 $albumArt['src'] = SSP_PLUGIN_URL . '/assets/images/no-album-art.png';
                                 $albumArt['width'] = 300;
@@ -537,6 +541,8 @@ class SSP_Frontend {
 
                                     // On Media Finished
                                     window.ssp_player<?php echo $largePlayerInstanceNumber; ?>.on( 'finish', function(e){
+
+                                        $( '#ssp_player_id_<?php echo $largePlayerInstanceNumber; ?> #ssp-play-pause .ssp-icon' ).removeClass().addClass( 'ssp-icon ssp-icon-play_icon' );
 
                                         // Track Podcast Specific Finish
                                         /*_paq.push(
@@ -1272,7 +1278,7 @@ class SSP_Frontend {
 			wp_send_json( $reponse );
 		}
 	}
-	
+
 	/**
 	 * Public facing action which is triggered from Seriously Simple Hosting
 	 * Updates episode_id and audio_file data from import process
@@ -1979,7 +1985,7 @@ class SSP_Frontend {
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	public function load_scripts(){
 

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,11 @@ You can find complete user and developer documentation (along with the FAQs) on 
 
 == Changelog ==
 
+= 1.19.1 =
+* 2017-11-21
+* [FIX] Increased width and height of new player album art to avoid 1px line under player wrapper
+* [FIX] Fixed bug where default feed image was not showing for the album art if not series image was set
+
 = 1.19.0-alpha =
 * 2017-11-17
 * [NEW] Added support for featured images

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 1.19.0-alpha
+ * Version: 1.19.1
  * Plugin URI: https://www.castos.com/seriously-simple-podcasting
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -38,7 +38,7 @@ if ( version_compare( PHP_VERSION, '5.3.3', '<' ) ) { // PHP 5.3.3 or greater
 	return;
 }
 
-define( 'SSP_VERSION', '1.19.0-alpha' );
+define( 'SSP_VERSION', '1.19.1' );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 


### PR DESCRIPTION
## 1.19.0-alpha.2

### 2017-11-21
* [_FIX_] Increased width and height of new player album art to avoid 1px line under player wrapper
* [_FIX_] Fixed bug where default feed image was not showing for the album art if not series image was set