### PR TITLE
Feature / Multiple Player Improvments

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -295,6 +295,69 @@ class SSP_Frontend {
 	}
 
 	/**
+     * Get Album Art for Player
+     *
+     * Iteratively tries to find the correct album art based on whether the desired image is of square aspect ratio.
+     * Falls back to default album art if it can not find the correct ones.
+     *
+	 * @param $episode_id ID of the episode being loaded into the player
+     *
+	 * @return array [ $src, $width, $height ]
+     *
+     * @since 1.19.4
+	 */
+	public function get_album_art( $episode_id = false ) {
+
+	    if( !$episode_id ){
+		    $src = SSP_PLUGIN_URL . '/assets/images/no-album-art.png';
+		    $width  = 300;
+		    $height = 300;
+		    return compact( 'src', 'width', 'height' );
+        }
+
+		$series_id = false;
+
+		if ( $series = get_the_terms( $episode_id, 'series' ) ) {
+			$series_id = ( ! empty( $series ) && isset( $series[0] ) ) ? $series[0]->term_id : false;
+		}
+
+		if ( $series_id && $series_image = get_option( "ss_podcasting_data_image_{$series_id}" ) ) {
+			$series_image_attachment_id = ssp_get_image_id_from_url( $series_image );
+			list( $src, $width, $height ) = wp_get_attachment_image_src( $series_image_attachment_id, 'medium' );
+
+			if( ( $width / $height ) !== 1 ){
+				if( $series_image = get_option( "ss_podcasting_data_image" ) ) {
+					$series_image_attachment_id = ssp_get_image_id_from_url( $series_image );
+					list( $src, $width, $height ) = wp_get_attachment_image_src( $series_image_attachment_id, 'medium' );
+
+					if ( ( $width / $height ) !== 1 ) {
+						$src = SSP_PLUGIN_URL . '/assets/images/no-album-art.png';
+						$width  = 300;
+						$height = 300;
+						return compact( 'src', 'width', 'height' );
+					}
+					return compact( 'src', 'width', 'height' );
+				}
+			}
+			return compact( 'src', 'width', 'height' );
+		}elseif( $series_id && $series_image = get_option( "ss_podcasting_data_image" ) ) {
+			$series_image_attachment_id = ssp_get_image_id_from_url( $series_image );
+			list( $src, $width, $height ) = wp_get_attachment_image_src( $series_image_attachment_id, 'medium' );
+			if ( ( $width / $height ) !== 1 ) {
+				$src = SSP_PLUGIN_URL . '/assets/images/no-album-art.png';
+				$width  = 300;
+				$height = 300;
+			}
+			return compact( 'src', 'width', 'height' );
+		}else{
+			$src = SSP_PLUGIN_URL . '/assets/images/no-album-art.png';
+			$width  = 300;
+			$height = 300;
+			return compact( 'src', 'width', 'height' );
+		}
+	}
+
+	/**
 	 * Load media player for given file
 	 * @param  string  $srcFile        Source of file
 	 * @param  integer $episode_id Episode ID for audio file
@@ -340,31 +403,16 @@ class SSP_Frontend {
 						$thumb_id = get_post_thumbnail_id( $episode_id );
 
 						if ( ! empty( $thumb_id ) ) {
-							list( $src, $width, $height ) = wp_get_attachment_image_src( $thumb_id, 'full' );
+
+						    list( $src, $width, $height ) = wp_get_attachment_image_src( $thumb_id, 'full' );
+
 							$albumArt = compact( 'src', 'width', 'height' );
-						} else {
 
-							// First fall back to series image, and then finally a no album art image
-							$series_id = false;
-
-							if( $series = get_the_terms( $episode_id, 'series' ) ){
-								$series_id = ( !empty( $series ) && isset( $series[0] ) ) ? $series[0]->term_id : false;
-							}
-
-                            if( $series_id && $series_image = get_option( "ss_podcasting_data_image_{$series_id}" ) ){
-                                $series_image_attachment_id = ssp_get_image_id_from_url( $series_image );
-                                list( $src, $width, $height ) = wp_get_attachment_image_src( $series_image_attachment_id, 'medium' );
-                                $albumArt = compact( 'src', 'width', 'height' );
-                            }elseif( $series_image = get_option( "ss_podcasting_data_image" ) ){
-	                            $series_image_attachment_id = ssp_get_image_id_from_url( $series_image );
-	                            list( $src, $width, $height ) = wp_get_attachment_image_src( $series_image_attachment_id, 'medium' );
-	                            $albumArt = compact( 'src', 'width', 'height' );
-                            }else{
-                                $albumArt['src'] = SSP_PLUGIN_URL . '/assets/images/no-album-art.png';
-                                $albumArt['width'] = 300;
-                                $albumArt['height'] = 300;
+							if( ( $width / $height ) !== 1 ){
+								$albumArt = $this->get_album_art( $episode_id );
                             }
-                        }
+
+						}
 
 						$player_background_colour = get_option( 'ss_podcasting_player_background_skin_colour', false );
 						$player_wave_form_colour = get_option( 'ss_podcasting_player_wave_form_colour', false );

--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -107,6 +107,9 @@ class SSP_Frontend {
 		// Load fonts, styles and javascript
 		add_action( 'wp_enqueue_scripts', array( $this, 'load_styles_and_scripts' ) );
 
+		// Enqueue HTML5 scripts only if the page has an HTML5 player on it
+        add_action( 'wp_print_footer_scripts', array( $this, 'html5_player_conditional_scripts' ) );
+
 		// Add overridable styles to footer
 		add_action( 'wp_footer', array( $this, 'ssp_override_player_styles' ) );
 
@@ -115,6 +118,17 @@ class SSP_Frontend {
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'load_scripts' ) );
 	}
+
+	public function html5_player_conditional_scripts(){
+		global $largePlayerInstanceNumber;
+		if( (int) $largePlayerInstanceNumber > 0 ){
+		    echo '<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,700&v=' . SSP_VERSION . '" />';
+		    echo '<link rel="stylesheet" href="' . SSP_PLUGIN_URL . 'assets/css/icon_fonts.css?v=' . SSP_VERSION . '" />';
+		    echo '<link rel="stylesheet" href="' . SSP_PLUGIN_URL . 'assets/fonts/Gizmo/gizmo.css?v=' . SSP_VERSION . '" />';
+			echo '<link rel="stylesheet" href="' . SSP_PLUGIN_URL . 'assets/css/frontend.css?v=' . SSP_VERSION . '" />';
+		    echo '<script src="//cdnjs.cloudflare.com/ajax/libs/wavesurfer.js/1.4.0/wavesurfer.min.js?v=' . SSP_VERSION . '"></script>';
+        }
+    }
 
 	public function ssp_override_player_styles(){
 		$player_wave_form_progress_colour = get_option( 'ss_podcasting_player_wave_form_progress_colour', false );
@@ -132,11 +146,11 @@ class SSP_Frontend {
 	 * Enqueue styles and scripts
 	 */
 	public function load_styles_and_scripts(){
-		wp_enqueue_style( 'google-font-robotto' , '//fonts.googleapis.com/css?family=Roboto:400,700', array(), SSP_VERSION);
+		/*wp_enqueue_style( 'google-font-robotto' , '//fonts.googleapis.com/css?family=Roboto:400,700', array(), SSP_VERSION);
 		wp_enqueue_style( 'ssp-player-styles', SSP_PLUGIN_URL . 'assets/css/icon_fonts.css', array( 'google-font-robotto' ), SSP_VERSION );
 		wp_enqueue_style( 'ssp-player-gizmo', SSP_PLUGIN_URL . 'assets/fonts/Gizmo/gizmo.css', array( 'ssp-player-styles' ), SSP_VERSION );
 		wp_enqueue_script( 'ssp-player-waveform', '//cdnjs.cloudflare.com/ajax/libs/wavesurfer.js/1.4.0/wavesurfer.min.js', array( 'jquery' ), SSP_VERSION );
-		wp_enqueue_style( 'ssp-large-player-styles', SSP_PLUGIN_URL . 'assets/css/frontend.css', array( 'ssp-player-styles' ), SSP_VERSION );
+		wp_enqueue_style( 'ssp-large-player-styles', SSP_PLUGIN_URL . 'assets/css/frontend.css', array( 'ssp-player-styles' ), SSP_VERSION );*/
 	}
 
 	/**
@@ -361,9 +375,10 @@ class SSP_Frontend {
 	 * Load media player for given file
 	 * @param  string  $srcFile        Source of file
 	 * @param  integer $episode_id Episode ID for audio file
+     * @param  string $player_size mini or large
 	 * @return string              Media player HTML on success, empty string on failure
 	 */
-	public function media_player ( $srcFile = '', $episode_id = 0 ) {
+	public function media_player ( $srcFile = '', $episode_id = 0, $player_size = "large" ) {
 
 		global $largePlayerInstanceNumber;
 		$largePlayerInstanceNumber++;
@@ -392,8 +407,11 @@ class SSP_Frontend {
 				case 'audio' :
 
 					$player_style = (string) get_option( 'ss_podcasting_player_style' );
+					if( $player_size == "large" ){
+						$player_style = "larger";
+                    }
 
-					if( "larger" !== $player_style ){
+					if( "larger" !== $player_style || "mini" === $player_size ){
 						$player = wp_audio_shortcode( $params );
 					}else{
 
@@ -1712,7 +1730,7 @@ class SSP_Frontend {
 	 * @param  array   $content_items Orderd array of content items to display
 	 * @return string                 HTML of episode with specified content items
 	 */
-	public function podcast_episode ( $episode_id = 0, $content_items = array( 'title', 'player', 'details' ), $context = '', $style = 'large' ) {
+	public function podcast_episode ( $episode_id = 0, $content_items = array( 'title', 'player', 'details' ), $context = '', $style = 'mini' ) {
 
 		global $post, $episode_context, $largePlayerInstanceNumber;
 
@@ -1764,251 +1782,45 @@ class SSP_Frontend {
 			 * @todo Add filters
 			 * @todo Add settings pages to customize layout / colours
 			 */
-			$meta = $this->episode_meta_details( $episode_id, $episode_context, true );
-			$file = $this->get_enclosure( $episode_id );
 
 			if( 'mini' !== $style ){
 				if( 'large' == $style ){
-					ob_start();
-					?>
-						<div class="ssp-player ssp-player-large" id="ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?>"<?php echo $player_background_colour ? ' style="background: ' . $player_background_colour . ';"' : null ;?>>
-							<div class="ssp-album-art-container">
-							   <div class="ssp-album-art" style="background: url( <?php echo $albumArt['src']; ?> ) center center no-repeat; -webkit-background-size: cover;background-size: cover;"></div>
-							</div>
-							<div style="overflow: hidden">
-								<div class="ssp-player-inner" style="overflow: hidden;">
-									<div class="ssp-player-info">
-										<div style="width: 80%; float:left;">
-											<h3 class="ssp-player-title episode-title">
-												<?php echo get_the_title(); ?>
-											</h3>
-											<div>&nbsp;</div>
-										</div>
-										<div class="ssp-download-episode" style="overflow: hidden;text-align:right;">
-											<span class="ssp-open-in-new-window">
-												<span class="icon-new-tab">&nbsp;</span>
-											</span>
-											<a href="<?php echo $file; ?>?ref=download" target="_blank">
-												<span class="icon-cloud-download">&nbsp;</span>
-											</a>
-										</div>
-										<div>&nbsp;</div>
-										<!--<div class="ssp-player-episode-details">
-											<?php /*echo $this->episode_meta_details( $episode_id, $episode_context ); */?>
-										</div>-->
-										<div class="ssp-media-player">
-											<div class="ssp-custom-player-controls">
-												<div class="ssp-play-pause" id="ssp-play-pause">
-													<span class="icon icon-play2">&nbsp;</span>
-												</div>
-												<div class="ssp-wave-form">
-													<div class="ssp-inner">
-														<div id="waveform<?php echo $episode_id . $largePlayerInstanceNumber; ?>" class="ssp-wave"></div>
-														<div class="ssp-time-volume">
 
-															<div class="ssp-duration">
-																<span id="sspPlayedDuration">00:00</span> / <span id="sspTotalDuration"><?php echo $meta['duration']; ?></span>
-															</div>
+					foreach ( $content_items as $item ) {
 
-															<div class="ssp-volume">
+						switch( $item ) {
 
-																<div class="ssp-back-thirty-container" id="ssp-back-thirty">
-																	<div class="ssp-back-thirty-control" style="background: url(<?php echo content_url("plugins/seriously-simple-podcasting/assets/svg/ssp_back_30.svg"); ?>) center center no-repeat;"></div>
-																</div>
+							case 'title':
+								$html .= '<h3 class="episode-title">' . get_the_title() . '</h3>' . "\n";
+								break;
 
-																<!--<div class="ssp-playback-speed-container" id="ssp-playback-speed" style="float:left;">
-																	<div class="ssp-playback-speed-control" style="background: url(<?php /*echo content_url("plugins/seriously-simple-podcasting/assets/svg/ssp_speed.svg"); */?>) center center no-repeat;"></div>
-																</div>-->
+							case 'excerpt':
+								$html .= '<p class="episode-excerpt">' . get_the_excerpt() . '</p>' . "\n";
+								break;
 
-																<div class="ssp-playback-speed-label-container">
-																	<div class="ssp-playback-speed-label-wrapper">
-																		<span id="ssp_playback_speed<?php echo $episode_id . $largePlayerInstanceNumber; ?>" data-ssp-playback-rate="1">1x</span>
-																	</div>
-																</div>
+							case 'content':
+								$html .= '<div class="episode-content">' . apply_filters( 'the_content', get_the_content() ) . '</div>' . "\n";
+								break;
 
-																<!--<div class="volume" title="Set Volume" style="margin-left: 10px;">
-																   <span class="volumeBar"></span>
-																</div>-->
-															</div>
+							case 'player':
+								$file = $this->get_enclosure( $episode_id );
+								if ( get_option( 'permalink_structure' ) ) {
+									$file = $this->get_episode_download_link( $episode_id );
+								}
+								$html .= '<div class="podcast_player">' . $this->media_player( $file, $episode_id, "large" ) . '</div>' . "\n";
+								break;
 
-														</div>
-													</div>
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-							</div>
-						</div>
+							case 'details':
+								$html .= $this->episode_meta_details( $episode_id, $episode_context );
+								break;
 
-						<script>
+							case 'image':
+								$html .= get_the_post_thumbnail( $episode_id, apply_filters( 'ssp_frontend_context_thumbnail_size', 'thumbnail' ) );
+								break;
 
-							String.prototype.toFormattedDuration = function () {
-								var sec_num = parseInt(this, 10); // don't forget the second param
-								var hours   = Math.floor(sec_num / 3600);
-								var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
-								var seconds = sec_num - (hours * 3600) - (minutes * 60);
-
-								if (hours   < 10) {hours   = "0"+hours;}
-								if (minutes < 10) {minutes = "0"+minutes;}
-								if (seconds < 10) {seconds = "0"+seconds;}
-								return hours > 0 ? ( hours+':'+ minutes+':'+seconds) : (minutes+':'+seconds);
-							}
-
-							jQuery( document ).ready( function($){
-
-								var sspUpdateDuration<?php echo $episode_id . $largePlayerInstanceNumber; ?>;
-
-								var ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?> = WaveSurfer.create({
-									container: '#waveform<?php echo $episode_id . $largePlayerInstanceNumber; ?>',
-									waveColor: '<?php echo $player_wave_form_colour ? $player_wave_form_colour : "#eee"; ?>',
-									progressColor: '<?php echo $player_wave_form_progress_colour ? $player_wave_form_progress_colour : "#28c0e1"; ?>',
-									barWidth: 3,
-									barHeight: 15,
-									height: 30,
-									hideScrollbar: true,
-									skipLength: 30
-								});
-
-								ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.load('<?php echo $file; ?>');
-
-								ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.on( 'ready', function(e){
-									$( '#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> #sspTotalDuration' ).text( ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.getDuration().toString().toFormattedDuration() );
-								} );
-
-								ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.on( 'play', function(e){
-									$( '#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> #ssp-play-pause .icon' ).removeClass().addClass( 'icon icon-pause' );
-									$( '#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> #sspPlayedDuration' ).text( ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.getCurrentTime().toString().toFormattedDuration() )
-									sspUpdateDuration<?php echo $episode_id . $largePlayerInstanceNumber; ?> = setInterval( function(){
-										$( '#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> #sspPlayedDuration' ).text( ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.getCurrentTime().toString().toFormattedDuration() );
-									}, 100 );
-								} );
-
-								ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.on( 'pause', function(e){
-									$( '#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> #ssp-play-pause .icon' ).removeClass().addClass( 'icon icon-play2' );
-									clearInterval( sspUpdateDuration<?php echo $episode_id . $largePlayerInstanceNumber; ?> );
-								} );
-
-								$('#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> #ssp-play-pause').on( 'click', function(e){
-									ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.playPause();
-								} );
-
-								$('#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> #ssp-back-thirty').on( 'click', function(e){
-									ssp_player<?php echo $episode_id. $largePlayerInstanceNumber; ?>.skipBackward();
-								} );
-
-								$('#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> #ssp_playback_speed<?php echo $episode_id . $largePlayerInstanceNumber; ?>').on( 'click', function(e){
-									switch( $( e.currentTarget ).parent().find( '[data-ssp-playback-rate]' ).attr( 'data-ssp-playback-rate' ) ){
-										case "1":
-											$( e.currentTarget ).parent().find( '[data-ssp-playback-rate]' ).attr( 'data-ssp-playback-rate', '1.5' );
-											$( e.currentTarget ).parent().find( '[data-ssp-playback-rate]' ).text('1.5x' );
-											ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.setPlaybackRate(1.5);
-											break;
-										case "1.5":
-											$( e.currentTarget ).parent().find( '[data-ssp-playback-rate]' ).attr( 'data-ssp-playback-rate', '2' );
-											$( e.currentTarget ).parent().find( '[data-ssp-playback-rate]' ).text('2x' );
-											ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.setPlaybackRate(2);
-											break;
-										case "2":
-											$( e.currentTarget ).parent().find( '[data-ssp-playback-rate]' ).attr( 'data-ssp-playback-rate', '1' );
-											$( e.currentTarget ).parent().find( '[data-ssp-playback-rate]' ).text('1x' );
-											ssp_player<?php echo $episode_id . $largePlayerInstanceNumber; ?>.setPlaybackRate(1);
-										default:
-											break;
-									}
-								} );
-
-								/*$( '#ssp_player_id_<?php echo $episode_id . $largePlayerInstanceNumber; ?> .ssp-open-in-new-window' ).on( 'click', function( e ){
-									var sspNewWindow<?php echo $episode_id . $largePlayerInstanceNumber; ?> = window.open('','sspPlayerWindow<?php echo $episode_id . $largePlayerInstanceNumber; ?>');
-									sspNewWindow<?php echo $episode_id . $largePlayerInstanceNumber; ?>.document.write('<html><head>' + ( $('head').html() ) +'</head><body>');
-									sspNewWindow<?php echo $episode_id . $largePlayerInstanceNumber; ?>.document.write( $( e.currentTarget ).parents( '.ssp-player' ).html() );
-									sspNewWindow<?php echo $episode_id . $largePlayerInstanceNumber; ?>.document.write('</body></html>');
-								} );*/
-
-								/*var volumeDrag = false;
-								$('.volume').on('mousedown', function (e) {
-									volumeDrag = true;
-									audio.muted = false;
-									$('.sound').removeClass('muted');
-									updateVolume(e.pageX);
-								});
-								$(document).on('mouseup', function (e) {
-									if (volumeDrag) {
-										volumeDrag = false;
-										updateVolume(e.pageX);
-									}
-								});
-								$(document).on('mousemove', function (e) {
-									if (volumeDrag) {
-										updateVolume(e.pageX);
-									}
-								});
-								var updateVolume = function (x, vol) {
-									var volume = $('.ssp-volume .volume');
-									var percentage;
-									//if only volume have specificed
-									//then direct update volume
-									if (vol) {
-										percentage = vol * 100;
-									} else {
-										var position = x - volume.offset().left;
-										percentage = 100 * position / volume.width();
-									}
-
-									if (percentage > 100) {
-										percentage = 100;
-									}
-									if (percentage < 0) {
-										percentage = 0;
-									}
-
-									//update volume bar and video volume
-									$('.volumeBar').css('width', percentage + '%');
-									audio.volume = percentage / 100;
-
-									//change sound icon based on volume
-									if ( audio.volume == 0 ) {
-										$('.sound').removeClass('sound2').addClass('muted');
-									} else if (audio.volume > 0.5) {
-										$('.sound').removeClass('muted').addClass('sound2');
-									} else {
-										$('.sound').removeClass('muted').removeClass('sound2');
-									}
-								}*/
-							} );
-
-						</script>
-
-					<?php
-					$html .= ob_get_clean();
-				}
-
-				$share_url_array = array();
-
-				if( $itunes_share_url = get_option( 'ss_podcasting_itunes_url_' . $episode_series ) ){
-					$share_url_array['Apple iTunes'] = $itunes_share_url;
-				}
-
-				if( $stitcher_share_url = get_option( 'ss_podcasting_stitcher_url_' . $episode_series ) ){
-					$share_url_array['Stitcher'] = $stitcher_share_url;
-				}
-
-				if( $google_play_share_url = get_option( 'ss_podcasting_google_play_url_' . $episode_series ) ){
-					$share_url_array['Google Play'] = $google_play_share_url;
-				}
-
-				if( !empty( $share_url_array ) ){
-					$sh = 0;
-					$html .= '<aside class="ssp-subscribe-controls">';
-					$html .= 'Subscribe on: ';
-					foreach( $share_url_array as $share_title => $share_url ){
-						$html .= '<a href="' . $share_url . '" target="_blank">' . $share_title . '</a>';
-						$sh++;
-						$html .= ( $sh < count( $share_url_array ) ? ' | ' : NULL );
+						}
 					}
-					$html .= '</aside>';
-				}
-
+                }
 			}
 
 			if( 'mini' === $style ){
@@ -2034,7 +1846,7 @@ class SSP_Frontend {
 						if ( get_option( 'permalink_structure' ) ) {
 							$file = $this->get_episode_download_link( $episode_id );
 						}
-						$html .= '<div class="podcast_player">' . $this->media_player( $file, $episode_id ) . '</div>' . "\n";
+						$html .= '<div class="podcast_player">' . $this->media_player( $file, $episode_id, $style ) . '</div>' . "\n";
 					break;
 
 					case 'details':

--- a/includes/shortcodes/class-ssp-shortcode-podcast_playlist.php
+++ b/includes/shortcodes/class-ssp-shortcode-podcast_playlist.php
@@ -33,17 +33,18 @@ class SSP_Shortcode_Podcast_Playlist {
 
 		// Parse shortcode attributes
 		$atts = shortcode_atts( array(
-			'type'		=> 'audio',
-			'series'	=> '',
-			'order'		=> 'ASC',
-			'orderby'	=> 'menu_order ID',
-			'include'	=> '',
-			'exclude'   => '',
-			'style'		=> 'light',
-			'tracklist' => true,
-			'tracknumbers' => true,
-			'images'	=> true,
-            'limit'     => -1
+			'type'		    => 'audio',
+			'series'	    => '',
+			'order'		    => 'ASC',
+			'orderby'	    => 'menu_order ID',
+			'include'	    => '',
+			'exclude'       => '',
+			'style'		    => 'light',
+			'player_style'  => 'mini',
+			'tracklist'     => true,
+			'tracknumbers'  => true,
+			'images'	    => true,
+            'limit'         => -1
 		), $params, 'podcast_playlist' );
 
 		// Included posts must be passed as an array
@@ -188,7 +189,9 @@ class SSP_Shortcode_Podcast_Playlist {
 
 		ob_start();
 
-        $player_style = (string) get_option( 'ss_podcasting_player_style' );
+        //$player_style = (string) get_option( 'ss_podcasting_player_style' ); // Not taking into account global settings for now
+        //$player_style = $atts['player_style'];
+		$player_style = "mini";
 
 		if ( 1 === $instance && "larger" !== $player_style ) {
 			/* This hook is defined in wp-includes/media.php */
@@ -199,7 +202,7 @@ class SSP_Shortcode_Podcast_Playlist {
             <?php
 
                 if( 'audio' === $atts['type'] && "larger" == $player_style ){
-                    echo $ss_podcasting->media_player( $ss_podcasting->get_episode_download_link( $episodes[0]->ID ), $episodes[0]->ID );
+                    echo $ss_podcasting->media_player( $ss_podcasting->get_episode_download_link( $episodes[0]->ID ), $episodes[0]->ID, "large" );
                 }else{
                     ?>
                         <<?php echo $safe_type ?> controls="controls" preload="none" width="<?php

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,14 @@ You can find complete user and developer documentation (along with the FAQs) on 
 
 == Changelog ==
 
+= 1.20.0 =
+* 2017-12-12
+* [TWEAK] Iterate over various album art options for the HTML5 player, and use the first most appropriate one that is of square aspect ratio.
+* [TWEAK] Deferred loading of scripts and styles for new HTML5 player to the end of the <body> element, and only if at least one HTML5 player instance is present on the page, to avoid unnecessary loading of scripts.
+* [TWEAK] Updated podcast_episode shortcode to allow the use of a "style" shortcode attribute, with a value of "mini" or "large" to either use the compact native WordPress player or the new larger HTML5 media player.
+* [TWEAK] Updated podcast_playlist shortcode to force use of default WordPress media player instead of the new HTML5 player until some minor bugs are ironed out.
+
+
 = 1.19.3 =
 * 2017-12-08
 * [FIX] Namespaced CSS classes for icons to avoid conflicts with themes using font frameworks

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 1.19.4
+ * Version: 1.20.0
  * Plugin URI: https://www.castos.com/seriously-simple-podcasting
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -38,7 +38,7 @@ if ( version_compare( PHP_VERSION, '5.3.3', '<' ) ) { // PHP 5.3.3 or greater
 	return;
 }
 
-define( 'SSP_VERSION', '1.19.4' );
+define( 'SSP_VERSION', '1.20.0' );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 1.19.3
+ * Version: 1.19.4
  * Plugin URI: https://www.castos.com/seriously-simple-podcasting
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -38,7 +38,7 @@ if ( version_compare( PHP_VERSION, '5.3.3', '<' ) ) { // PHP 5.3.3 or greater
 	return;
 }
 
-define( 'SSP_VERSION', '1.19.3' );
+define( 'SSP_VERSION', '1.19.4' );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 


### PR DESCRIPTION
This PR contains many code enhancements and bug fixes for the new HTML5 player.

## Version 1.20.0
### 2017-12-12

* [_TWEAK_] Iterate over various album art options for the HTML5 player, and use the first most appropriate one that is of square aspect ratio.

* [_TWEAK_] Deferred loading of scripts and styles for new HTML5 player to the end of the _<body>_ element, and only if at least one HTML5 player instance is present on the page, to avoid unnecessary loading of scripts.

* [_TWEAK_] Updated **podcast_episode** shortcode to allow the use of a "_style_" shortcode attribute, with a value of "_mini_" or "_large_" to either use the compact native WordPress player or the new larger HTML5 media player.

* [_TWEAK_] Updated **podcast_playlist** shortcode to force use of default WordPress media player instead of the new HTML5 player until some minor bugs are ironed out.

