### PR TITLE
Add podcast post type to tag archive

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -84,6 +84,9 @@ class SSP_Frontend {
 		// Make sure to fetch all relevant post types when viewing series archive
 		add_action( 'pre_get_posts' , array( $this, 'add_all_post_types' ) );
 
+		// Make sure to fetch all relevant post types when viewing a tag archive
+		add_action( 'pre_get_posts' , array( $this, 'add_all_post_types_for_tag_archive' ) );
+
 		// Download podcast episode
 		add_action( 'wp', array( $this, 'download_file' ), 1 );
 
@@ -1213,6 +1216,25 @@ class SSP_Frontend {
 			}
 
 		}
+
+	}
+
+	public function add_all_post_types_for_tag_archive( $query ) {
+
+		if ( is_admin() ) {
+			return;
+		}
+
+		if ( ! $query->is_main_query() ) {
+			return;
+		}
+
+		if ( !is_tag() ) {
+			return;
+		}
+
+		$tag_archive_post_types = apply_filters( 'ssp_tag_archive_post_types', array('post', 'podcast') ) ;
+		$query->set( 'post_type', $tag_archive_post_types );
 
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: podcast, audio, video, vodcast, rss, mp3, mp4, feed, itunes, podcasting, m
 Requires at least: 4.4
 Tested up to: 4.9.1
 Requires PHP: 5.3.3
-Stable tag: 1.19.9
+Stable tag: 1.19.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,13 @@ You can find complete user and developer documentation (along with the FAQs) on 
 14. An example of the styled podcast RSS feed when viewed directly in the browser.
 
 == Changelog ==
+
+= 1.19.10 =
+* 2018-06-25
+* [FIX] Fixes a bug where using the ss_podcast shortcode with the episodes context argument doesn't show episode meta data.
+* [FIX] Adds the podcast post type to the Tag archive query.
+* [TWEAK] Removes the use of an anonymous function when loading conditional play styles
+* [TWEAK] Removing the upgrade notices related to the 1.19 release
 
 = 1.19.9 =
 * 2018-04-08

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 1.19.9
+ * Version: 1.19.10
  * Plugin URI: https://www.castos.com/seriously-simple-podcasting
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -38,7 +38,7 @@ if ( version_compare( PHP_VERSION, '5.3.3', '<' ) ) { // PHP 5.3.3 or greater
 	return;
 }
 
-define( 'SSP_VERSION', '1.19.9' );
+define( 'SSP_VERSION', '1.19.10' );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 


### PR DESCRIPTION
When rendering tag archives, the podcast post type is not included by default. This adds the podcast post type to the query.
Also implements a ssp_tag_archive_post_types filter to allow a user to further alter this list of allowable types