### PR TITLE
Release/1.20.5

### DIFF
--- a/php/classes/handlers/class-settings-handler.php
+++ b/php/classes/handlers/class-settings-handler.php
@@ -577,6 +577,14 @@ class Settings_Handler {
 				'callback'    => 'wp_strip_all_tags',
 			),
 			array(
+				'id'          => 'turbocharge_feed',
+				'label'       => __( 'Turbocharge podcast feed', 'seriously-simple-podcasting' ),
+				'description' => sprintf( __( 'When enabled, this setting will speed up your feed loading time. %1$sMore details here.%2$s', 'seriously-simple-podcasting' ), '<a href="' . esc_url( 'https://support.castos.com/article/89-turbocharging-your-feed-to-maximize-available-episodes' ) . '" target="' . wp_strip_all_tags( '_blank' ) . '">', '</a>' ),
+				'type'        => 'checkbox',
+				'default'     => '',
+				'callback'    => 'wp_strip_all_tags',
+			),
+			array(
 				'id'          => 'new_feed_url',
 				'label'       => __( 'New podcast feed URL', 'seriously-simple-podcasting' ),
 				'description' => __( 'Your podcast feed\'s new URL.', 'seriously-simple-podcasting' ),

--- a/php/includes/ssp-functions.php
+++ b/php/includes/ssp-functions.php
@@ -354,7 +354,13 @@ if ( ! function_exists( 'ssp_episodes' ) ) {
 		);
 
 		if ( $series ) {
-			$args['series'] = esc_attr( $series );
+			$args['tax_query'] = array(
+				array(
+					'taxonomy' => 'series',
+					'field'    => 'slug',
+					'terms'    => esc_attr( $series )
+				)
+			);
 		}
 
 		$args = apply_filters( 'ssp_episode_query_args', $args, $context );

--- a/readme.txt
+++ b/readme.txt
@@ -102,7 +102,11 @@ You can find complete user and developer documentation (along with the FAQs) on 
 
 == Changelog ==
 
-= 1.20.4=
+= 1.20.5-beta =
+* 2019-07-04
+* [NEW] Add the ability to turbo charge the load times of the RSS feed, by limiting certain fields
+
+= 1.20.4 =
 * 2019-07-01
 * [FIX] Fixes a bug introduced by 1.20.0 which breaks password protecting a feed
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: podcast, audio, video, vodcast, rss, mp3, mp4, feed, itunes, podcasting, m
 Requires at least: 4.4
 Tested up to: 5.2
 Requires PHP: 5.6
-Stable tag: 1.20.4
+Stable tag: 1.20.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -102,9 +102,11 @@ You can find complete user and developer documentation (along with the FAQs) on 
 
 == Changelog ==
 
-= 1.20.5-beta =
-* 2019-07-04
+= 1.20.5 =
+* 2019-07-10
 * [NEW] Add the ability to turbo charge the load times of the RSS feed, by limiting certain fields
+* [CHANGE] Updated the RSS feed description tag, itunes:summary tag and googleplay:description tag to meet RSS feed requirements
+* [FIX] Fixes a bug when retrieving posts by series
 
 = 1.20.4 =
 * 2019-07-01

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 1.20.4
+ * Version: 1.20.5-beta
  * Plugin URI: https://www.castos.com/seriously-simple-podcasting
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -26,7 +26,7 @@ use SeriouslySimplePodcasting\Controllers\Settings_Controller;
 use SeriouslySimplePodcasting\Controllers\Options_Controller;
 use SeriouslySimplePodcasting\Rest\Rest_Api_Controller;
 
-define( 'SSP_VERSION', '1.20.4' );
+define( 'SSP_VERSION', '1.20.5-beta' );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 

--- a/seriously-simple-podcasting.php
+++ b/seriously-simple-podcasting.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Seriously Simple Podcasting
- * Version: 1.20.5-beta
+ * Version: 1.20.5
  * Plugin URI: https://www.castos.com/seriously-simple-podcasting
  * Description: Podcasting the way it's meant to be. No mess, no fuss - just you and your content taking over the world.
  * Author: Castos
@@ -26,7 +26,7 @@ use SeriouslySimplePodcasting\Controllers\Settings_Controller;
 use SeriouslySimplePodcasting\Controllers\Options_Controller;
 use SeriouslySimplePodcasting\Rest\Rest_Api_Controller;
 
-define( 'SSP_VERSION', '1.20.5-beta' );
+define( 'SSP_VERSION', '1.20.5' );
 define( 'SSP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SSP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -444,21 +444,17 @@ $turbo = get_option( 'ss_podcasting_turbocharge_feed', 'off' );
 				$author = esc_html( get_the_author() );
 				$author = apply_filters( 'ssp_feed_item_author', $author, get_the_ID() );
 
-				// Episode content (with iframes removed)
+				// Episode content (with shortcodes and iframes removed)
 				$content = get_the_content_feed( 'rss2' );
+				$content = strip_shortcodes( $content );
 				$content = preg_replace( '/<\/?iframe(.|\s)*?>/', '', $content );
 				$content = apply_filters( 'ssp_feed_item_content', $content, get_the_ID() );
 
-				// iTunes summary is the full episode content, but must be shorter than 4000 characters
-				$itunes_summary = mb_substr( $content, 0, 3999 );
-				$itunes_summary = apply_filters( 'ssp_feed_item_itunes_summary', $itunes_summary, get_the_ID() );
-				$gp_description = apply_filters( 'ssp_feed_item_gp_description', $itunes_summary, get_the_ID() );
-
-				// Episode description
-				ob_start();
-				the_excerpt_rss();
-				$description = ob_get_clean();
-				$description = apply_filters( 'ssp_feed_item_description', $description, get_the_ID() );
+				// Description, iTunes summary and Google Play description is the full episode content, but must be shorter than 4000 characters
+				$description    = mb_substr( $content, 0, 3999 );
+				$itunes_summary = apply_filters( 'ssp_feed_item_itunes_summary', $description, get_the_ID() );
+				$gp_description = apply_filters( 'ssp_feed_item_gp_description', $description, get_the_ID() );
+				$description    = apply_filters( 'ssp_feed_item_description', $description, get_the_ID() );
 
 				// iTunes subtitle does not allow any HTML and must be shorter than 255 characters
 				$itunes_subtitle = strip_tags( strip_shortcodes( $description ) );
@@ -515,7 +511,7 @@ $turbo = get_option( 'ss_podcasting_turbocharge_feed', 'off' );
 					<pubDate><?php echo $pubDate; ?></pubDate>
 					<dc:creator><?php echo $author; ?></dc:creator>
 					<guid isPermaLink="false"><?php esc_html( the_guid() ); ?></guid>
-					<description><![CDATA[<?php echo $content; ?>]]></description>
+					<description><![CDATA[<?php echo $description; ?>]]></description>
 					<itunes:subtitle><![CDATA[<?php echo $itunes_subtitle; ?>]]></itunes:subtitle>
 					<?php if ( $keywords ) : ?>
 						<itunes:keywords><?php echo $keywords; ?></itunes:keywords>

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -515,7 +515,7 @@ $turbo = get_option( 'ss_podcasting_turbocharge_feed', 'off' );
 					<pubDate><?php echo $pubDate; ?></pubDate>
 					<dc:creator><?php echo $author; ?></dc:creator>
 					<guid isPermaLink="false"><?php esc_html( the_guid() ); ?></guid>
-					<description><![CDATA[<?php echo $description; ?>]]></description>
+					<description><![CDATA[<?php echo $content; ?>]]></description>
 					<itunes:subtitle><![CDATA[<?php echo $itunes_subtitle; ?>]]></itunes:subtitle>
 					<?php if ( $keywords ) : ?>
 						<itunes:keywords><?php echo $keywords; ?></itunes:keywords>

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -242,22 +242,17 @@ $category1 = ssp_get_feed_category_output( 1, $series_id );
 $category2 = ssp_get_feed_category_output( 2, $series_id );
 $category3 = ssp_get_feed_category_output( 3, $series_id );
 
-// Get stylehseet URL (filterable to allow custom RSS stylesheets)
-$stylehseet_url = apply_filters( 'ssp_rss_stylesheet', $ss_podcasting->template_url . 'feed-stylesheet.xsl' );
-
 // Set RSS content type and charset headers
 header( 'Content-Type: ' . feed_content_type( 'podcast' ) . '; charset=' . get_option( 'blog_charset' ), true );
 
 // Use `echo` for first line to prevent any extra characters at start of document
 echo '<?xml version="1.0" encoding="' . get_option( 'blog_charset' ) . '"?>' . "\n";
 
-// Include RSS stylesheet
-if ( $stylehseet_url ) {
-	echo '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylehseet_url ) . '"?>';
-}
-
 // Get iTunes Type
 $itunes_type = get_option( 'ss_podcasting_consume_order' . ( $series_id > 0 ? '_' . $series_id : null ) );
+
+$turbo = get_option( 'ss_podcasting_turbocharge_feed', 'off' );
+
 ?>
 
 <rss version="2.0"
@@ -289,22 +284,17 @@ $itunes_type = get_option( 'ss_podcasting_consume_order' . ( $series_id > 0 ? '_
 			<?php
 		}
 		?>
-		<googleplay:author><?php echo esc_html( $author ); ?></googleplay:author>
-		<googleplay:email><?php echo esc_html( $owner_email ); ?></googleplay:email>
 		<itunes:summary><?php echo esc_html( $podcast_description ); ?></itunes:summary>
-		<googleplay:description><?php echo esc_html( $podcast_description ); ?></googleplay:description>
 		<itunes:owner>
 			<itunes:name><?php echo esc_html( $owner_name ); ?></itunes:name>
 			<itunes:email><?php echo esc_html( $owner_email ); ?></itunes:email>
 		</itunes:owner>
 		<itunes:explicit><?php echo esc_html( $itunes_explicit ); ?></itunes:explicit>
-		<googleplay:explicit><?php echo esc_html( $googleplay_explicit ); ?></googleplay:explicit>
 		<?php if ( $complete ) { ?>
 			<itunes:complete><?php echo esc_html( $complete ); ?></itunes:complete><?php }
 		if ( $image ) {
 			?>
 			<itunes:image href="<?php echo esc_url( $image ); ?>"></itunes:image>
-			<googleplay:image href="<?php echo esc_url( $image ); ?>"></googleplay:image>
 			<image>
 				<url><?php echo esc_url( $image ); ?></url>
 				<title><?php echo esc_html( $title ); ?></title>
@@ -334,8 +324,18 @@ $itunes_type = get_option( 'ss_podcasting_consume_order' . ( $series_id > 0 ? '_
 		<?php } ?>
 		<?php if ( $new_feed_url ) { ?>
 			<itunes:new-feed-url><?php echo esc_url( $new_feed_url ); ?></itunes:new-feed-url>
-		<?php }
+		<?php } ?>
+		<?php if ( 'off' === $turbo ) { ?>
+			<googleplay:author><?php echo esc_html( $author ); ?></googleplay:author>
+			<googleplay:email><?php echo esc_html( $owner_email ); ?></googleplay:email>
+			<googleplay:description><?php echo esc_html( $podcast_description ); ?></googleplay:description>
+			<googleplay:explicit><?php echo esc_html( $googleplay_explicit ); ?></googleplay:explicit>
+			<?php if ( $image ) { ?>
+				<googleplay:image href="<?php echo esc_url( $image ); ?>"></googleplay:image>
+			<?php } ?>
+		<?php } ?>
 
+		<?php
 		// Prevent WP core from outputting an <image> element
 		remove_action( 'rss2_head', 'rss2_site_icon' );
 
@@ -348,6 +348,10 @@ $itunes_type = get_option( 'ss_podcasting_consume_order' . ( $series_id > 0 ? '_
 		$args = ssp_episodes( $num_posts, $podcast_series, true, 'feed' );
 
 		$qry = new WP_Query( $args );
+
+		if ( 'on' === $turbo ) {
+			$post_count = 0;
+		}
 
 		if ( $qry->have_posts() ) {
 			while ( $qry->have_posts() ) {
@@ -398,7 +402,6 @@ $itunes_type = get_option( 'ss_podcasting_consume_order' . ( $series_id > 0 ? '_
 					}
 				}
 				$size = apply_filters( 'ssp_feed_item_size', $size, get_the_ID() );
-
 
 				// File MIME type (default to MP3/MP4 to ensure there is always a value for this)
 				$mime_type = $ss_podcasting->get_attachment_mimetype( $audio_file );
@@ -502,6 +505,9 @@ $itunes_type = get_option( 'ss_podcasting_consume_order' . ( $series_id > 0 ? '_
 					$itunes_episode_number = get_post_meta( get_the_ID(), 'itunes_episode_number', true );
 					$itunes_season_number  = get_post_meta( get_the_ID(), 'itunes_season_number', true );
 				}
+				if ( isset( $post_count ) ) {
+					$post_count ++;
+				}
 				?>
 				<item>
 					<title><?php esc_html( the_title_rss() ); ?></title>
@@ -526,20 +532,28 @@ $itunes_type = get_option( 'ss_podcasting_consume_order' . ( $series_id > 0 ? '_
 					<?php if ( $itunes_season_number ): ?>
 						<itunes:season><?php echo $itunes_season_number; ?></itunes:season>
 					<?php endif; ?>
-					<content:encoded><![CDATA[<?php echo $content; ?>]]></content:encoded>
-					<itunes:summary><![CDATA[<?php echo $itunes_summary; ?>]]></itunes:summary>
-					<googleplay:description><![CDATA[<?php echo $gp_description; ?>]]></googleplay:description>
-					<?php if ( $episode_image ) { ?>
-						<itunes:image href="<?php echo esc_url( $episode_image ); ?>"></itunes:image>
-						<googleplay:image href="<?php echo esc_url( $episode_image ); ?>"></googleplay:image>
+					<?php if ( isset( $post_count ) && $post_count <= 10 ) { ?>
+						<content:encoded><![CDATA[<?php echo $content; ?>]]></content:encoded>
 					<?php } ?>
 					<enclosure url="<?php echo esc_url( $enclosure ); ?>" length="<?php echo esc_attr( $size ); ?>" type="<?php echo esc_attr( $mime_type ); ?>"></enclosure>
+					<?php if ( isset( $post_count ) && $post_count <= 10 ) { ?>
+						<itunes:summary><![CDATA[<?php echo $itunes_summary; ?>]]></itunes:summary>
+					<?php } ?>
+					<?php if ( $episode_image ) { ?>
+						<itunes:image href="<?php echo esc_url( $episode_image ); ?>"></itunes:image>
+					<?php } ?>
 					<itunes:explicit><?php echo esc_html( $itunes_explicit_flag ); ?></itunes:explicit>
-					<googleplay:explicit><?php echo esc_html( $googleplay_explicit_flag ); ?></googleplay:explicit>
 					<itunes:block><?php echo esc_html( $block_flag ); ?></itunes:block>
-					<googleplay:block><?php echo esc_html( $block_flag ); ?></googleplay:block>
 					<itunes:duration><?php echo esc_html( $duration ); ?></itunes:duration>
 					<itunes:author><?php echo $author; ?></itunes:author>
+					<?php if ( 'off' === $turbo ) { ?>
+						<googleplay:description><![CDATA[<?php echo $gp_description; ?>]]></googleplay:description>
+						<?php if ( $episode_image ) { ?>
+							<googleplay:image href="<?php echo esc_url( $episode_image ); ?>"></googleplay:image>
+						<?php } ?>
+						<googleplay:explicit><?php echo esc_html( $googleplay_explicit_flag ); ?></googleplay:explicit>
+						<googleplay:block><?php echo esc_html( $block_flag ); ?></googleplay:block>
+					<?php } ?>
 				</item>
 			<?php }
 		} ?>


### PR DESCRIPTION
[NEW] Add the ability to turbo charge the load times of the RSS feed, by limiting certain fields
[CHANGE] Updated the RSS feed description tag, itunes:summary tag and googleplay:description tag to meet RSS feed requirements
[FIX] Fixes a bug when retrieving posts by series