### PR TITLE
Only increment when player size is large or larger.

### DIFF
--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -493,10 +493,10 @@ class Frontend_Controller extends Controller {
 			$player_size = 'mini';
 		}
 
-        if ( $player_size == 'large' || $player_size == 'larger' ) {
-    		global $large_player_instance_number;
-    		$large_player_instance_number++;
-        }
+		if ( $player_size == 'large' || $player_size == 'larger' ) {
+			global $large_player_instance_number;
+			$large_player_instance_number++;
+		}
 
 		$player = '';
 
@@ -1606,9 +1606,9 @@ class Frontend_Controller extends Controller {
 		$player_wave_form_colour = get_option( 'ss_podcasting_player_wave_form_colour', false );
 		$player_wave_form_progress_colour = get_option( 'ss_podcasting_player_wave_form_progress_colour', false );
 
-        if ( $style == 'large' || $style == 'larger' ) {
-            $large_player_instance_number+= 1;
-        }
+		if ( $style == 'large' || $style == 'larger' ) {
+			$large_player_instance_number+= 1;
+		}
 
 		if ( ! $episode_id || ! is_array( $content_items ) || empty( $content_items ) ) {
 			return;

--- a/php/classes/controllers/class-frontend-controller.php
+++ b/php/classes/controllers/class-frontend-controller.php
@@ -493,8 +493,10 @@ class Frontend_Controller extends Controller {
 			$player_size = 'mini';
 		}
 
-		global $large_player_instance_number;
-		$large_player_instance_number++;
+        if ( $player_size == 'large' || $player_size == 'larger' ) {
+    		global $large_player_instance_number;
+    		$large_player_instance_number++;
+        }
 
 		$player = '';
 
@@ -1604,7 +1606,9 @@ class Frontend_Controller extends Controller {
 		$player_wave_form_colour = get_option( 'ss_podcasting_player_wave_form_colour', false );
 		$player_wave_form_progress_colour = get_option( 'ss_podcasting_player_wave_form_progress_colour', false );
 
-		$large_player_instance_number+= 1;
+        if ( $style == 'large' || $style == 'larger' ) {
+            $large_player_instance_number+= 1;
+        }
 
 		if ( ! $episode_id || ! is_array( $content_items ) || empty( $content_items ) ) {
 			return;


### PR DESCRIPTION
#401 

In 2 places `$large_player_instance_number` was always getting incremented even if the player had the standard/mini style. Now a large/larger style is required. When on a page without large/larger style players the additional assets for the large player will not be loaded.