### PR TITLE
Removing trailing space on category name

### DIFF
--- a/php/classes/handlers/class-settings-handler.php
+++ b/php/classes/handlers/class-settings-handler.php
@@ -226,7 +226,7 @@ class Settings_Handler {
 				'group' => __( 'Leisure', 'seriously-simple-podcasting' ),
 			),
 			'Music Commentary '  => array(
-				'label' => __( 'Music Commentary ', 'seriously-simple-podcasting' ),
+				'label' => __( 'Music Commentary', 'seriously-simple-podcasting' ),
 				'group' => __( 'Music', 'seriously-simple-podcasting' ),
 			),
 			'Music History'      => array(


### PR DESCRIPTION
Remove the trailing space on the "Music Commentary" category that was causing it not to save correctly.

Fixes #410