### PR TITLE
Add filter for track data in playlist shortcode

### DIFF
--- a/php/classes/shortcodes/class-podcast-playlist.php
+++ b/php/classes/shortcodes/class-podcast-playlist.php
@@ -181,6 +181,9 @@ class Podcast_Playlist {
 					$track['thumb'] = '';
 				}
 			}
+			
+			// Allow dynamic filtering of track data
+			$track = apply_filters( 'ssp_podcast_playlist_track_data', $track, $episode );
 
 			$tracks[] = $track;
 		}


### PR DESCRIPTION
Add the `ssp_podcast_playlist_track_data` filter to allow dynamic filtering of individual tracks in the playlist shortcode.

Fixes #174