### PR TITLE
Localising PHP version error message

### DIFF
--- a/php/includes/ssp-functions.php
+++ b/php/includes/ssp-functions.php
@@ -22,13 +22,14 @@ if ( ! function_exists( 'ssp_is_php_version_ok' ) ) {
 		 */
 		add_action( 'admin_notices', 'ssp_php_version_notice' );
 		function ssp_php_version_notice() {
+			$error_notice = __( 'The Seriously Simple Podcasting plugin requires PHP version 5.6 or higher. Please contact your web host to upgrade your PHP version or deactivate the plugin.', 'seriously-simple-podcasting' );
+			$error_notice_apology = __( 'We apologise for any inconvenience.', 'seriously-simple-podcasting' );
 			?>
 			<div class="error">
 				<p>
-					<strong>The Seriously Simple Podcasting plugin requires PHP version 5.6 or higher. Please
-						contact your web host to upgrade your PHP version or deactivate the plugin.</strong>.
+					<strong><?php echo $error_notice; ?></strong>.
 				</p>
-				<p>We apologise for any inconvenience.</p>
+				<p><?php echo $error_notice_apology; ?></p>
 			</div>
 			<?php
 		}


### PR DESCRIPTION
Localise the PHP version error message when a version lower than 5.6 is being used. I did not change the content of the message at all.

Fixes #415