### PR TITLE
Add context to localisation of podcast URL slug

### DIFF
--- a/php/classes/controllers/class-options-controller.php
+++ b/php/classes/controllers/class-options-controller.php
@@ -461,7 +461,7 @@ class Options_Controller extends Controller {
 				$html .= esc_url( $url ) . "\n";
 				break;
 			case 'podcast_url':
-				$slug        = apply_filters( 'ssp_archive_slug', __( 'podcast', 'seriously-simple-podcasting' ) );
+				$slug        = apply_filters( 'ssp_archive_slug', _x( 'podcast', 'Podcast URL slug', 'seriously-simple-podcasting' ) );
 				$podcast_url = $this->home_url . $slug;
 
 				$html .= '<a href="' . esc_url( $podcast_url ) . '" target="_blank">' . $podcast_url . '</a>';

--- a/php/classes/controllers/class-settings-controller.php
+++ b/php/classes/controllers/class-settings-controller.php
@@ -565,7 +565,7 @@ class Settings_Controller extends Controller {
 				$html .= esc_url( $url ) . "\n";
 				break;
 			case 'podcast_url':
-				$slug        = apply_filters( 'ssp_archive_slug', __( 'podcast', 'seriously-simple-podcasting' ) );
+				$slug        = apply_filters( 'ssp_archive_slug', _x( 'podcast', 'Podcast URL slug', 'seriously-simple-podcasting' ) );
 				$podcast_url = $this->home_url . $slug;
 
 				$html .= '<a href="' . esc_url( $podcast_url ) . '" target="_blank">' . $podcast_url . '</a>';


### PR DESCRIPTION
Add context to localisation of podcast URL slug to prevent URLs changing when translated.

Fixes #326