### PR TITLE
#462 clean up after shortcode globals

### DIFF
--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -502,6 +502,9 @@ xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
 				$author = esc_html( get_the_author() );
 				$author = apply_filters( 'ssp_feed_item_author', $author, get_the_ID() );
 
+				// Cache the post in case it changes
+				$post_id = get_the_ID();
+
 				// Episode content (with shortcodes and iframes removed)
 				$content = get_the_content_feed( 'rss2' );
 				$content = strip_shortcodes( $content );
@@ -521,6 +524,11 @@ xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
 					}
 				}
 				$description = apply_filters( 'ssp_feed_item_description', $description, get_the_ID() );
+
+				// Clean up after shortcodes in content and excerpts
+				if( $post_id !== get_the_ID() ) {
+					$qry->reset_postdata();
+				}
 
 				// iTunes summary excludes HTML and must be shorter than 4000 characters
 				$itunes_summary = wp_strip_all_tags( $description );


### PR DESCRIPTION
I don't know why the display-posts shortcode is changing the page global - it appears to properly clean up after itself - but it's widely used and this issue has been reported elsewhere in the forums - so here we are. In any case this PR solves for the general case of any misbehaving shortcodes in the podcast content.